### PR TITLE
systemd_%.bbappend: add our patches for v229.

### DIFF
--- a/recipes-core/systemd/systemd/229/0001-nspawn-don-t-check-binary-OS-tree-before-all-mounts-.patch
+++ b/recipes-core/systemd/systemd/229/0001-nspawn-don-t-check-binary-OS-tree-before-all-mounts-.patch
@@ -1,0 +1,75 @@
+From 0a95296b24d636377a58592f1a30eb4312e5d3d2 Mon Sep 17 00:00:00 2001
+From: Krisztian Litkey <krisztian.litkey@intel.com>
+Date: Tue, 8 Dec 2015 16:02:56 +0200
+Subject: [PATCH 1/2] nspawn: don't check binary/OS-tree before all mounts are
+ in place.
+
+Do not check if the binary to run is in place or if the given
+directory looks like an OS tree hierarchy *before* we have put
+all the requested bind- and overlay-mounts in place. It is
+possible that some of the mounts are responsible for pulling in
+the necessary bits and pieces for a successful check.
+
+Upstream-Status: Pending
+
+Signed-off-by: Krisztian Litkey <krisztian.litkey@intel.com>
+---
+ src/nspawn/nspawn.c | 35 +++++++++++++++++------------------
+ 1 file changed, 17 insertions(+), 18 deletions(-)
+
+diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
+index ef348c3..50f4892 100644
+--- a/src/nspawn/nspawn.c
++++ b/src/nspawn/nspawn.c
+@@ -2802,6 +2802,23 @@ static int outer_child(
+         if (r < 0)
+                 return r;
+ 
++        /* Now that everything is mounted, check if we have the necessary binary/directory tree to continue. */
++        if (arg_start_mode == START_BOOT) {
++                if (path_is_os_tree(arg_directory) <= 0) {
++                        log_error("Directory %s doesn't look like an OS root directory (os-release file is missing). Refusing.", arg_directory);
++                        return -EINVAL;
++                }
++        } else {
++                const char *p;
++
++                p = strjoina(arg_directory, "/usr");
++
++                if (laccess(p, F_OK) < 0) {
++                        log_error("Directory %s doesn't look like it has an OS tree. Refusing.", arg_directory);
++                        return -EINVAL;
++                }
++        }
++
+         r = mount_move_root(directory);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to move root directory: %m");
+@@ -3205,24 +3222,6 @@ int main(int argc, char *argv[]) {
+                                 }
+                         }
+                 }
+-
+-                if (arg_start_mode == START_BOOT) {
+-                        if (path_is_os_tree(arg_directory) <= 0) {
+-                                log_error("Directory %s doesn't look like an OS root directory (os-release file is missing). Refusing.", arg_directory);
+-                                r = -EINVAL;
+-                                goto finish;
+-                        }
+-                } else {
+-                        const char *p;
+-
+-                        p = strjoina(arg_directory, "/usr/");
+-                        if (laccess(p, F_OK) < 0) {
+-                                log_error("Directory %s doesn't look like it has an OS tree. Refusing.", arg_directory);
+-                                r = -EINVAL;
+-                                goto finish;
+-                        }
+-                }
+-
+         } else {
+                 char template[] = "/tmp/nspawn-root-XXXXXX";
+ 
+-- 
+2.5.0
+

--- a/recipes-core/systemd/systemd/229/0002-nspawn-added-support-for-starting-DHCP-client-in-non.patch
+++ b/recipes-core/systemd/systemd/229/0002-nspawn-added-support-for-starting-DHCP-client-in-non.patch
@@ -1,0 +1,203 @@
+From 9c37ad63f49b8218ae40e4aa22f7a9035b42e088 Mon Sep 17 00:00:00 2001
+From: Krisztian Litkey <krisztian.litkey@intel.com>
+Date: Fri, 18 Dec 2015 12:44:11 +0200
+Subject: [PATCH 2/2] nspawn: added support for starting DHCP client in
+ non-system containers.
+
+Added --auto-dhcp option for starting a DHCP client in the container
+before privileges are dropped or the actual container command gets
+executed. This is done only for non-system containers started without
+--share-system.
+
+The DHCP client command can be specified as an argument to the option.
+If none is specified {/sbin,/usr/sbin}/{dhclient,udhcpc} are tried in
+this particular order. The network interface name is assumed to be
+'host0'.
+
+Upstream-Status: Pending
+
+Signed-off-by: Krisztian Litkey <krisztian.litkey@intel.com>
+---
+ src/nspawn/nspawn-network.c | 86 +++++++++++++++++++++++++++++++++++++++++++++
+ src/nspawn/nspawn-network.h |  2 ++
+ src/nspawn/nspawn.c         | 18 ++++++++++
+ 3 files changed, 106 insertions(+)
+
+diff --git a/src/nspawn/nspawn-network.c b/src/nspawn/nspawn-network.c
+index fcb1efa..13c76e6 100644
+--- a/src/nspawn/nspawn-network.c
++++ b/src/nspawn/nspawn-network.c
+@@ -31,6 +31,8 @@
+ #include "siphash24.h"
+ #include "string-util.h"
+ #include "udev-util.h"
++#include "fd-util.h"
++#include "signal-util.h"
+ #include "util.h"
+ 
+ #define HOST_HASH_KEY SD_ID128_MAKE(1a,37,6f,c7,46,ec,45,0b,ad,a3,d5,31,06,60,5d,b1)
+@@ -538,3 +540,87 @@ int veth_extra_parse(char ***l, const char *p) {
+         a = b = NULL;
+         return 0;
+ }
++
++int spawn_dhcp_client(const char *dhcp_client, pid_t *rpid) {
++        pid_t pid;
++        const char *interface = "host0";
++        const char *argv[16];
++
++        pid = fork();
++        if (pid < 0)
++                return log_error_errno(errno, "Failed to fork dhclient: %m");
++        else if (pid == 0) {
++                int nullfd;
++                char *empty_env = NULL;
++
++                nullfd = open("/dev/null", O_RDWR);
++                if (nullfd < 0)
++                        _exit(EXIT_FAILURE);
++
++                if (dup3(nullfd, STDIN_FILENO, 0) < 0)
++                        _exit(EXIT_FAILURE);
++
++                if (dup3(nullfd, STDOUT_FILENO, 0) < 0)
++                        _exit(EXIT_FAILURE);
++
++                if (dup3(nullfd, STDERR_FILENO, 0) < 0)
++                        _exit(EXIT_FAILURE);
++
++                if (nullfd > 2)
++                        safe_close(nullfd);
++
++                (void) reset_all_signal_handlers();
++                (void) reset_signal_mask();
++                close_all_fds(NULL, 0);
++
++                if (dhcp_client) {
++                        char **args = strv_split(dhcp_client, " ");
++                        char **a;
++                        int i;
++
++                        if (args == NULL)
++                                _exit(EXIT_FAILURE);
++
++                        i = 0;
++                        STRV_FOREACH(a, args) {
++                                if (i >= (int)ELEMENTSOF(argv) - 1)
++                                        _exit(EXIT_FAILURE);
++
++                                if (i == 0) {
++                                        char *p = strrchr(*a, '/');
++
++                                        argv[i] = p ? p + 1 : *a;
++                                }
++                                else
++                                        argv[i] = *a;
++                        }
++                        argv[i] = interface;
++
++                        execve(args[0], (char *const *)argv, &empty_env);
++                        _exit(EXIT_FAILURE);
++                }
++                else {
++                        argv[0] = "dhclient";
++                        argv[1] = interface;
++                        argv[2] = NULL;
++
++                        execve("/usr/sbin/dhclient", (char *const*)argv, &empty_env);
++                        execve("/sbin/dhclient", (char *const*)argv, &empty_env);
++
++                        argv[0] = "udhcpc";
++                        argv[1] = "-i";
++                        argv[2] = interface;
++                        argv[3] = NULL;
++
++                        execve("/usr/sbin/udhcpc", (char *const*)argv, &empty_env);
++                        execve("/sbin/udhcpc", (char *const*)argv, &empty_env);
++
++                        _exit(EXIT_FAILURE);
++                }
++        }
++
++        if (rpid != NULL)
++                *rpid = pid;
++
++        return 0;
++}
+diff --git a/src/nspawn/nspawn-network.h b/src/nspawn/nspawn-network.h
+index 9ab1606..fd9fb99 100644
+--- a/src/nspawn/nspawn-network.h
++++ b/src/nspawn/nspawn-network.h
+@@ -34,3 +34,5 @@ int setup_ipvlan(const char *machine_name, pid_t pid, char **ifaces);
+ int move_network_interfaces(pid_t pid, char **ifaces);
+ 
+ int veth_extra_parse(char ***l, const char *p);
++
++int spawn_dhcp_client(const char *dhcp_client, pid_t *rpid);
+diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
+index 50f4892..35b610f 100644
+--- a/src/nspawn/nspawn.c
++++ b/src/nspawn/nspawn.c
+@@ -121,6 +121,8 @@ static const char *arg_selinux_context = NULL;
+ static const char *arg_selinux_apifs_context = NULL;
+ static const char *arg_slice = NULL;
+ static bool arg_private_network = false;
++static char *arg_dhcp_client = NULL;
++static bool arg_auto_dhcp = false;
+ static bool arg_read_only = false;
+ static StartMode arg_start_mode = START_PID1;
+ static bool arg_ephemeral = false;
+@@ -348,6 +350,7 @@ static int parse_argv(int argc, char *argv[]) {
+                 ARG_KILL_SIGNAL,
+                 ARG_SETTINGS,
+                 ARG_CHDIR,
++                ARG_AUTO_DHCP,
+         };
+ 
+         static const struct option options[] = {
+@@ -394,6 +397,7 @@ static int parse_argv(int argc, char *argv[]) {
+                 { "kill-signal",           required_argument, NULL, ARG_KILL_SIGNAL       },
+                 { "settings",              required_argument, NULL, ARG_SETTINGS          },
+                 { "chdir",                 required_argument, NULL, ARG_CHDIR             },
++                { "auto-dhcp",             optional_argument, NULL, ARG_AUTO_DHCP         },
+                 {}
+         };
+ 
+@@ -882,6 +886,11 @@ static int parse_argv(int argc, char *argv[]) {
+                         arg_settings_mask |= SETTING_WORKING_DIRECTORY;
+                         break;
+ 
++                case ARG_AUTO_DHCP:
++                        arg_auto_dhcp = true;
++                        arg_dhcp_client = optarg;
++                        break;
++
+                 case '?':
+                         return -EINVAL;
+ 
+@@ -932,6 +941,11 @@ static int parse_argv(int argc, char *argv[]) {
+                 return -EINVAL;
+         }
+ 
++        if (arg_auto_dhcp && (arg_start_mode == START_BOOT || arg_share_system)) {
++                log_error("--dhcp-client may not be combined with --boot or --share-system.");
++                return -EINVAL;
++        }
++
+         if (arg_userns && access("/proc/self/uid_map", F_OK) < 0)
+                 return log_error_errno(EOPNOTSUPP, "--private-users= is not supported, kernel compiled without user namespace support.");
+ 
+@@ -2531,6 +2545,10 @@ static int inner_child(
+                 rtnl_socket = safe_close(rtnl_socket);
+         }
+ 
++        if (arg_private_network && arg_auto_dhcp)
++                if (spawn_dhcp_client(arg_dhcp_client, NULL) < 0)
++                        return log_error_errno(errno, "spawn_dhcp_client() failed: %m");
++
+         r = drop_capabilities();
+         if (r < 0)
+                 return log_error_errno(r, "drop_capabilities() failed: %m");
+-- 
+2.5.0
+

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -6,12 +6,20 @@ PACKAGECONFIG_append = " iptc networkd"
 # Patch systemd-nspawn to
 #   - delay binary/OS-tree check after mounts
 #   - support starting DHCP client in non-system containers
-SYSTEMD_228_PATCHES = " \
+SYSTEMD_APPFW_PATCHES_228 = " \
     file://228/0001-nspawn-don-t-check-binary-OS-tree-before-all-mounts-.patch \
     file://228/0002-nspawn-added-support-for-starting-DHCP-client-in-non.patch \
 "
 
-SRC_URI += "${SYSTEMD_228_PATCHES}"
+# 0001-nspawn-don-t-check-binary-OS-tree-before-all-mounts-.patch might no longer
+# be needed (code that it moved around is gone), but 0002-nspawn-added-support-for-starting-DHCP-client-in-non.patch
+# might be needed.
+#
+# TODO: port it to 229...
+SYSTEMD_APPFW_PATCHES_229 = " \
+"
+
+SRC_URI += " ${@d.getVar('SYSTEMD_APPFW_PATCHES_' + d.getVar('PV', False)[0:3], True) or ''}"
 
 # systemd-nspawn needs getent (from glibc).
 RDEPENDS_${PN} += "glibc-getent"

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -11,12 +11,9 @@ SYSTEMD_APPFW_PATCHES_228 = " \
     file://228/0002-nspawn-added-support-for-starting-DHCP-client-in-non.patch \
 "
 
-# 0001-nspawn-don-t-check-binary-OS-tree-before-all-mounts-.patch might no longer
-# be needed (code that it moved around is gone), but 0002-nspawn-added-support-for-starting-DHCP-client-in-non.patch
-# might be needed.
-#
-# TODO: port it to 229...
 SYSTEMD_APPFW_PATCHES_229 = " \
+    file://229/0001-nspawn-don-t-check-binary-OS-tree-before-all-mounts-.patch \
+    file://229/0002-nspawn-added-support-for-starting-DHCP-client-in-non.patch \
 "
 
 SRC_URI += " ${@d.getVar('SYSTEMD_APPFW_PATCHES_' + d.getVar('PV', False)[0:3], True) or ''}"


### PR DESCRIPTION
Added support for automatically applying the right version-specific patches to systemd.
Ported our patches on top of systemd v229 and added them as version-specific patches.
