### PR TITLE
iot-app-fw_git.bb: update to latest version.

### DIFF
--- a/recipes-appfw/example-app-c/files/src/manifest.in
+++ b/recipes-appfw/example-app-c/files/src/manifest.in
@@ -1,17 +1,31 @@
 {
-    "application": "nativetest",
-    "description": "test native application to see if the infra worked",
-    "provider": "yoyodine",
-    "groups": "yoyodine-nativetest",
-    "environment": {
-        "FROB": "nicate",
-        "FOOBAR": "xyzzy",
+    'application': {
+        'origin':      'yoyodine',
+        'name':        'nativetest',
+        'description': 'nativetest - native dummy test applcation.',
+        'install':     'echo "Nothing to be done for installing..."',
+        'remove':      'echo "Nothing to be done for removing..."',
     },
-    "command": [ "@bindir@/hello-world" ],
-    "autostart": "false",
-     "container": {
-        "type": "nspawn",
-        "network": "VirtualEthernet",
-        "sharedsystem": false,
+
+    'service': {
+        'groups': [ 'yoyodine-nativetest' ],
+        'environment': {
+            'FROB': 'nicate',
+            'FOOBAR': 'xyzzy',
+        },
+
+        'start': [
+            '@bindir@/hello-world',
+         ],
+        'stop': '',
+
+        'autostart': true,
+    },
+
+    'container': {
+        'type': 'nspawn-app',
+        'network': {
+            'type': 'VirtualEthernet',
+        },
     },
 }

--- a/recipes-appfw/example-app-node/files/manifest
+++ b/recipes-appfw/example-app-node/files/manifest
@@ -1,17 +1,32 @@
 {
-    "application": "nodetest",
-    "description": "test node application to see if the infra worked",
-    "provider": "iodine",
-    "groups": "iodine-nodetest",
-    "environment": {
-        "FROB": "nicate",
-        "FOOBAR": "xyzzy"
+    'application': {
+        'origin':      'iodine',
+        'name':        'nodetest',
+        'description': 'nodetest - NodeJS dummy test applcation.',
+        'install':     'echo "Nothing to be done for installing..."',
+        'remove':      'echo "Nothing to be done for removing..."'
     },
-    "command": [  "/usr/bin/node", "/lib/node_modules/nodetest/example.js" ],
-    "autostart": "yes",
-    "container": {
-        "type": "nspawn",
-        "network": "VirtualEthernet",
-        "portmap": [ { "proto": "tcp", "host": 2000, "container": 12345 } ]
+
+    'service': {
+        'groups': [ 'iodine-nodetest' ],
+        'environment': {
+            'FROB': 'nicate',
+            'FOOBAR': 'xyzzy'
+        },
+
+        'start': [
+            '/usr/bin/node /lib/node_modules/nodetest/example.js'
+         ],
+        'stop': '',
+
+        'autostart': true
+    },
+
+    'container': {
+        'type': 'nspawn-app',
+        'network': {
+            'type': 'VirtualEthernet',
+            'ports': [ { 'proto': 'tcp', 'port': 12345, 'map': 2000 } ]
+        }
     }
 }

--- a/recipes-appfw/example-app-python/files/manifest
+++ b/recipes-appfw/example-app-python/files/manifest
@@ -1,17 +1,32 @@
 {
-    "application": "pythontest",
-    "description": "test Python application to see if the infra worked",
-    "provider": "foodine",
-    "groups": "foodine-pythontest",
-    "environment": {
-        "FROB": "nicate",
-        "FOOBAR": "xyzzy"
+    'application': {
+        'origin':      'foodine',
+        'name':        'pythontest',
+        'description': 'pythontest - Python dummy test applcation.',
+        'install':     'echo "Nothing to be done for installing..."',
+        'remove':      'echo "Nothing to be done for removing..."'
     },
-    "command": [  "/usr/bin/python", "/lib/python/pythontest/example.py" ],
-    "autostart": "false",
-     "container": {
-        "type": "nspawn",
-        "network": "VirtualEthernet",
-        "portmap": [ { "proto": "tcp", "host": 2010, "container": 27279} ]
+
+    'service': {
+        'groups': [ 'foodine-pythontest' ],
+        'environment': {
+            'FROB': 'nicate',
+            'FOOBAR': 'xyzzy'
+        },
+
+        'start': [
+            '/usr/bin/python /lib/python/pythontest/example.py'
+         ],
+        'stop': '',
+
+        'autostart': false
+    },
+
+    'container': {
+        'type': 'nspawn-app',
+        'network': {
+            'type': 'VirtualEthernet',
+            'ports': [ { 'proto': 'tcp', 'port': 27279, 'map': 27279 } ]
+        }
     }
 }

--- a/recipes-appfw/iot-app-fw/files/appfw-packet-forward.conf
+++ b/recipes-appfw/iot-app-fw/files/appfw-packet-forward.conf
@@ -1,0 +1,2 @@
+net.ipv4.conf.all.forwarding = 1
+net.ipv6.conf.all.forwarding = 1

--- a/recipes-appfw/iot-app-fw/iot-app-fw_git.bb
+++ b/recipes-appfw/iot-app-fw/iot-app-fw_git.bb
@@ -10,6 +10,7 @@ SRC_URI = " \
     git://git@github.com/ostroproject/iot-app-fw.git;protocol=https;branch=kli/devel/1.x-fixes \
     file://80-container-host0.network \
     file://80-container-ve.network \
+    file://appfw-packet-forward.conf \
   "
 
 SRCREV = "7610344d05199a35103e04a2f08cee50397db7da"
@@ -28,6 +29,7 @@ FILES_${PN} = "${base_libdir}/systemd/system-generators/iot-service-generator \
                ${libexecdir}/iot-app-fw \
                ${libdir}/systemd/network/80-container-host0.network \
                ${libdir}/systemd/network/80-container-ve.network \
+               ${libdir}/sysctl.d/appfw-packet-forward.conf \
 "
 
 FILES_${PN}-dbg =+ "${base_libdir}/systemd/system-generators/.debug"
@@ -40,4 +42,7 @@ do_install_append () {
     mkdir -p ${D}${libdir}/systemd/network
     cp ../80-container-host0.network ${D}${libdir}/systemd/network
     cp ../80-container-ve.network ${D}${libdir}/systemd/network
+    install -m 0755 -o root -g root -d ${D}${libdir}/sysctl.d && \
+    install -m 0644 -o root -g root -t ${D}${libdir}/sysctl.d \
+        ../appfw-packet-forward.conf
 }

--- a/recipes-appfw/iot-app-fw/iot-app-fw_git.bb
+++ b/recipes-appfw/iot-app-fw/iot-app-fw_git.bb
@@ -7,13 +7,13 @@ LIC_FILES_CHKSUM = "file://LICENSE-BSD;md5=f9f435c1bd3a753365e799edf375fc42"
 DEPENDS = "json-c systemd"
 
 SRC_URI = " \
-    git://git@github.com/ostroproject/iot-app-fw.git;protocol=https;branch=kli/devel/1.x-fixes \
+    git://git@github.com/ostroproject/iot-app-fw.git;protocol=https;branch=kli/devel/1.x \
     file://80-container-host0.network \
     file://80-container-ve.network \
     file://appfw-packet-forward.conf \
   "
 
-SRCREV = "7610344d05199a35103e04a2f08cee50397db7da"
+SRCREV = "ed04e87a583b3ec73c56a629533c1ff74527133a"
 
 inherit autotools pkgconfig systemd
 

--- a/recipes-appfw/sample-node0/files/manifest.in
+++ b/recipes-appfw/sample-node0/files/manifest.in
@@ -1,21 +1,31 @@
 {
-    "application": "node0",
-    "description": "node0 - A dummy NodeJS application, running without a container.",
-    "provider": "test",
-    "groups": "test-node0",
-    "environment": {
-        "NODE0_FOO": "node0-foo",
-        "NODE0_BAR": "node0-bar",
+    'application': {
+        'origin':      'test',
+        'name':        'node0',
+        'description': 'node0 - dummy app running without containers.',
+        'install':     'echo "Nothing to be done for installing node0..."',
+        'remove':      'echo "Nothing to be done for removing node0..."',
     },
-    "command": [
-        "/usr/bin/node",
-        "@OSTRO_APP_ROOT@/lib/node_modules/node0/sample.js",
-        "2001",
-        "'test-node0 NodeJS sample application'",
-    ],
-    "autostart": "yes",
-    "container": {
-        "type":    "none",
-        "portmap": [ { "proto": "tcp", "host": 2001 } ],
+
+    'service': {
+        'groups': [ 'audio', 'cdrom', 'video' ],
+        'environment': {
+            'NODE0_FOO': 'node0-foo',
+            'NODE0_BAR': 'node0-bar',
+        },
+
+        'start': [
+            '/usr/bin/node @OSTRO_APP_ROOT@/lib/node_modules/node0/sample.js 2001 "test-node0 NodeJS dummy application"'
+        ],
+        'stop': '',
+
+        'autostart': true,
+    },
+
+    'container': {
+        'type': 'none',
+        'network': {
+            'ports': [ { 'proto': 'tcp', 'port': 2001 } ],
+        },
     },
 }

--- a/recipes-appfw/sample-node1/files/manifest
+++ b/recipes-appfw/sample-node1/files/manifest
@@ -1,22 +1,31 @@
 {
-    "application": "node1",
-    "description": "node1 - A dummy NodeJS application, running in a shared-system single-app container.",
-    "provider": "test",
-    "groups": "test-node1",
-    "environment": {
-        "NODE1_FOO": "node1-foo",
-        "NODE1_BAR": "node1-bar",
+    'application': {
+        'origin':      'test',
+        'name':        'node1',
+        'description': 'node1 - dummy app running in a shared container.',
+        'install':     'echo "Nothing to be done for installing node1..."',
+        'remove':      'echo "Nothing to be done for removing node1..."',
     },
-    "command": [
-        "/usr/bin/node",
-        "/lib/node_modules/node1/sample.js",
-        "23456",
-        "'test-node1 NodeJS sample application'",
-    ],
-    "autostart": "yes",
-    "container": {
-        "type":    "nspawn-shared",
-        "network": "VirtualEthernet",
-        "portmap": [ { "proto": "tcp", "host": 2002, "container": 23456 }, ],
+
+    'service': {
+        'groups': [ 'audio', 'cdrom', 'video' ],
+        'environment': {
+            'NODE1_FOO': 'node1-foo',
+            'NODE1_BAR': 'node1-bar',
+        },
+
+        'start': [
+            '/usr/bin/node /lib/node_modules/node1/sample.js 23457 "test-node1 NodeJS dummy application"' ],
+        'stop': '',
+
+        'autostart': true,
+    },
+
+    'container': {
+        'type': 'nspawn-shared',
+        'network': {
+            'type': 'VirtualEthernet',
+            'ports': [ { 'proto': 'tcp', 'port': 23457, 'map': 2002 } ],
+        },
     },
 }

--- a/recipes-appfw/sample-node2/files/manifest
+++ b/recipes-appfw/sample-node2/files/manifest
@@ -1,22 +1,32 @@
 {
-    "application": "node2",
-    "description": "node2 - A dummy NodeJS application, running in a single-app container.",
-    "provider": "test",
-    "groups": "test-node2",
-    "environment": {
-        "NODE2_FOO": "node2-foo",
-        "NODE2_BAR": "node2-bar",
+    'application': {
+        'origin':      'test',
+        'name':        'node2',
+        'description': 'node2 - dummy app running in an app container.',
+        'install':     'echo "Nothing to be done for installing node2..."',
+        'remove':      'echo "Nothing to be done for removing node2..."',
     },
-    "command": [
-        "/usr/bin/node",
-        "/lib/node_modules/node2/sample.js",
-        "23456",
-        "'test-node2 NodeJS sample application'",
-        ],
-    "autostart": "yes",
-    "container": {
-        "type":    "nspawn",
-        "network": "VirtualEthernet",
-        "portmap": [ { "proto": "tcp", "host": 2003, "container": 23456 }, ],
+
+    'service': {
+        'groups': [ 'audio', 'cdrom', 'video' ],
+        'environment': {
+            'NODE2_FOO': 'node2-foo',
+            'NODE2_BAR': 'node2-bar',
+        },
+
+        'start': [
+            '/usr/bin/node /lib/node_modules/node2/sample.js 23458 "test-node2 NodeJS dummy application"',
+         ],
+        'stop': '',
+
+        'autostart': true,
+    },
+
+    'container': {
+        'type': 'nspawn-app',
+        'network': {
+            'type': 'VirtualEthernet',
+            'ports': [ { 'proto': 'tcp', 'port': 23458, 'map': 2003 } ],
+        },
     },
 }

--- a/recipes-appfw/sample-node3/files/manifest
+++ b/recipes-appfw/sample-node3/files/manifest
@@ -1,22 +1,31 @@
 {
-    "application": "node3",
-    "description": "node3 - A dummy NodeJS application, running in a full system container.",
-    "provider": "test",
-    "groups": "test-node3",
-    "environment": {
-        "NODE3_FOO": "node3-foo",
-        "NODE3_BAR": "node3-bar",
+    'application': {
+        'origin':      'test',
+        'name':        'node3',
+        'description': 'node3 - dummy app running in a system container.',
+        'install':     'echo "Nothing to be done for installing node3..."',
+        'remove':      'echo "Nothing to be done for removing node3..."',
     },
-    "command": [
-        "/usr/bin/node",
-        "/lib/node_modules/node3/sample.js",
-        "23456",
-        "'test-node3 NodeJS sample application'",
-    ],
-    "autostart": "yes",
-    "container": {
-        "type":    "nspawn-system",
-        "network": "VirtualEthernet",
-        "portmap": [ { "proto": "tcp", "host": 2004, "container": 23456 }, ],
+
+    'service': {
+        'groups': [ 'audio', 'cdrom', 'video' ],
+        'environment': {
+            'NODE3_FOO': 'node3-foo',
+            'NODE3_BAR': 'node3-bar',
+        },
+
+        'start': [
+            '/usr/bin/node /lib/node_modules/node3/sample.js 23459 "test-node3 NodeJS dummy application"' ],
+        'stop': '',
+
+        'autostart': true,
+    },
+
+    'container': {
+        'type': 'nspawn-system',
+        'network': {
+            'type': 'VirtualEthernet',
+            'ports': [ { 'proto': 'tcp', 'port': 23459, 'map': 2004 } ],
+        },
     },
 }


### PR DESCRIPTION
Updated to latest service generator. This includes numerous bug fixes and
adds support for starting/running the service generator also inside a container
to prepare/start services (agentful mode).

Added new/updatedexisting templates for both agentful and agentless mode
according to the new template format.

Added a manifest preprocessor to convert manifests from the old to the new
format seemlessly on the fly.
