### PR TITLE
macros.inc: create /etc/machine-id inside container

### DIFF
--- a/recipes-appfw/iot-app-fw/iot-app-fw/0001-macros.inc-create-etc-machine-id-inside-container.patch
+++ b/recipes-appfw/iot-app-fw/iot-app-fw/0001-macros.inc-create-etc-machine-id-inside-container.patch
@@ -1,0 +1,45 @@
+From 2ba635e7f6c29dec9076cfc729564ffdf5aff1bf Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Date: Fri, 22 Jul 2016 17:10:10 +0300
+Subject: [PATCH] macros.inc: create /etc/machine-id inside container
+
+Recent versions of systemd-nspawn try to read /etc/machine-id
+before binding directories inside a container root directory.
+If the file doesn't exist systemd-nspawn refuses to create a
+container.
+
+The patch creates an empty /etc/machine-id if it's missing
+inside a container root directory.
+
+Upstream-Status: Submitted [https://github.com/ostroproject/iot-app-fw/pull/9]
+
+Fixes: IOTOS-1713
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+---
+ data/templates/ostro/host/macros.inc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/data/templates/ostro/host/macros.inc b/data/templates/ostro/host/macros.inc
+index 161bdc2..c3e5be6 100644
+--- a/data/templates/ostro/host/macros.inc
++++ b/data/templates/ostro/host/macros.inc
+@@ -17,6 +17,7 @@
+ {macro} MKDIR {do}/bin/mkdir -p{end}
+ {macro} IPT   {do}/usr/sbin/iptables -w{end}
+ {macro} CIF   {do}{TRUNCATE}({CONCAT}('ve-', {USER}), 15){end}
++{macro} TOUCH {do}/bin/touch{end}
+ 
+ {#} Macro for doing very basic manifest verification.
+ {macro} CHECK-MANIFEST(m) {do}
+@@ -62,6 +63,7 @@
+ .   ExecStartPre={MKDIR} {CR}/lib/../sbin/../bin/../usr
+ .   ExecStartPre={MKDIR} {CR}/root/../home/{USER}
+ .   ExecStartPre={MKDIR} {CR}/etc/../var/../tmp/
++.   ExecStartPre={TOUCH} {CR}/etc/machine-id
+ {end}
+ 
+ {#} Macros for various bind-, overlay-, and tmpfs-mounts.
+-- 
+2.5.5
+

--- a/recipes-appfw/iot-app-fw/iot-app-fw_git.bb
+++ b/recipes-appfw/iot-app-fw/iot-app-fw_git.bb
@@ -6,12 +6,12 @@ LIC_FILES_CHKSUM = "file://LICENSE-BSD;md5=f9f435c1bd3a753365e799edf375fc42"
 
 DEPENDS = "json-c systemd"
 
-SRC_URI = " \
-    git://git@github.com/ostroproject/iot-app-fw.git;protocol=https;branch=kli/devel/1.x \
-    file://80-container-host0.network \
-    file://80-container-ve.network \
-    file://appfw-packet-forward.conf \
-  "
+SRC_URI = "git://git@github.com/ostroproject/iot-app-fw.git;protocol=https;branch=kli/devel/1.x \
+           file://80-container-host0.network \
+           file://80-container-ve.network \
+           file://appfw-packet-forward.conf \
+           file://0001-macros.inc-create-etc-machine-id-inside-container.patch \
+           "
 
 SRCREV = "ed04e87a583b3ec73c56a629533c1ff74527133a"
 


### PR DESCRIPTION
Recent versions of systemd-nspawn try to read /etc/machine-id
before binding directories inside a container root directory.
If the file doesn't exist systemd-nspawn refuses to create a
container.

The patch creates an empty /etc/machine-id if it's missing
inside a container root directory.

Upstream-Status: Submitted [https://github.com/ostroproject/iot-app-fw/pull/9]

Fixes: IOTOS-1713

Signed-off-by: Dmitry Rozhkov dmitry.rozhkov@linux.intel.com
